### PR TITLE
Masonry zoom fix

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -105,7 +105,7 @@ h2 {
 
 h3 {
   &:before {
-    content: "——\00A0";
+    content: "—\00A0";
   }
 
   &.mentiontitle {
@@ -353,8 +353,9 @@ img {
     -moz-column-break-inside: avoid;
     break-inside: avoid;
     margin: 0;
-    padding-bottom: $border-radius;
-    padding-right: $border-radius / 1.5;
+    padding-bottom: calc(1px + 1vw);
+    padding-right: 8px;
+    padding-right: calc(1px + 0.7vw);
 
     img {
       width: 100%;
@@ -377,7 +378,7 @@ img {
 
     p {
       line-height: $line-h;
-      font-size: 0.39em;
+      font-size: 0.4em;
       font-size: calc(10px + 0.25vw);
       color: $lighter;
     }
@@ -440,11 +441,11 @@ side {
 }
 
 .invalid-link {
-  color: $lighter;
+  color: mix($site-background, white, 80%);
   cursor: help;
 }
 
 .invalid-link-brackets {
-  color: inherit;
+  color: mix($site-background, white, 90%);
   cursor: help;
 }


### PR DESCRIPTION
Set gap between images in masonry to responsive calc measurement that stays structurally sound when resizing or zooming in&out.